### PR TITLE
Adding possibility to return context keys for dynamically populate context.

### DIFF
--- a/Ruler.php
+++ b/Ruler.php
@@ -142,7 +142,7 @@ class Ruler {
         
         $interpreter = static::getInterpreter();
         //clear content keys
-        $interpreter->clearContentKeys();
+        $interpreter->clearContextKeys();
         
         return $interpreter->visit(
             static::getCompiler()->parse($rule)

--- a/Ruler.php
+++ b/Ruler.php
@@ -225,6 +225,17 @@ class Ruler {
 
         return static::$_compiler;
     }
+    
+    /**
+     * Get context keys.
+     *
+     * @access  public
+     * @return  array
+     */
+    public function getContextKeys ( $rule ) {
+
+        return static::getInterpreter()->getContextKeys();
+    }
 }
 
 }

--- a/Ruler.php
+++ b/Ruler.php
@@ -141,7 +141,7 @@ class Ruler {
     public static function interprete ( $rule ) {
         
         $interpreter = static::getInterpreter();
-        //clear content keys
+        //clear context keys
         $interpreter->clearContextKeys();
         
         return $interpreter->visit(

--- a/Ruler.php
+++ b/Ruler.php
@@ -139,8 +139,12 @@ class Ruler {
      * @throw   \Hoa\Ruler\Exception
      */
     public static function interprete ( $rule ) {
-
-        return static::getInterpreter()->visit(
+        
+        $interpreter = static::getInterpreter();
+        //clear content keys
+        $interpreter->clearContentKeys();
+        
+        return $interpreter->visit(
             static::getCompiler()->parse($rule)
         );
     }

--- a/Ruler.php
+++ b/Ruler.php
@@ -232,7 +232,7 @@ class Ruler {
      * @access  public
      * @return  array
      */
-    public function getContextKeys ( $rule ) {
+    public function getContextKeys ( ) {
 
         return static::getInterpreter()->getContextKeys();
     }

--- a/Visitor/Interpreter.php
+++ b/Visitor/Interpreter.php
@@ -288,6 +288,16 @@ class Interpreter implements \Hoa\Visitor\Visit {
 
         return $this->_contextKeys;
     }
+    
+    /**
+     * Clear context keys.
+     *
+     * @access  public
+     */
+    public function clearContextKeys ( ) {
+        
+        $this->_contextKeys = array();
+    }
 }
 
 }

--- a/Visitor/Interpreter.php
+++ b/Visitor/Interpreter.php
@@ -85,9 +85,9 @@ class Interpreter implements \Hoa\Visitor\Visit {
     protected $_current = null;
 
     /**
-     * Current node.
+     * Context keys.
      *
-     * @var \Hoa\Ruler\Visitor\Interpreter object
+     * @var array
      */
     protected $_contextKeys = array();
     
@@ -282,7 +282,7 @@ class Interpreter implements \Hoa\Visitor\Visit {
      * Get context keys.
      *
      * @access  public
-     * @return  \Hoa\Ruler\Model
+     * @return  array
      */
     public function getContextKeys ( ) {
 

--- a/Visitor/Interpreter.php
+++ b/Visitor/Interpreter.php
@@ -84,7 +84,13 @@ class Interpreter implements \Hoa\Visitor\Visit {
      */
     protected $_current = null;
 
-
+    /**
+     * Current node.
+     *
+     * @var \Hoa\Ruler\Visitor\Interpreter object
+     */
+    protected $_contextKeys = array();
+    
 
     /**
      * Visit an element.
@@ -219,9 +225,11 @@ class Interpreter implements \Hoa\Visitor\Visit {
                 switch($token) {
 
                     case 'identifier':
-                        return true === $variable
-                                   ? $this->_root->variable($value)
-                                   : $value;
+                        if (true === $variable) {
+                            array_push($this->_contextKeys, $value);
+                            return $this->_root->variable($value);
+                        }
+                        return $value;
 
                     case 'true':
                         return true;
@@ -268,6 +276,17 @@ class Interpreter implements \Hoa\Visitor\Visit {
     public function getRoot ( ) {
 
         return $this->_root;
+    }
+    
+    /**
+     * Get context keys.
+     *
+     * @access  public
+     * @return  \Hoa\Ruler\Model
+     */
+    public function getContextKeys ( ) {
+
+        return $this->_contextKeys;
     }
 }
 


### PR DESCRIPTION
In my case, I want to be able to populate my context dynamically so i've added this possibility.
The code will look something like this: 


        $ruler = new \Hoa\Ruler\Ruler();

        $rule  = 'group in ("customer", "guest") and points > 30';
        
        $rule =  \Hoa\Ruler\Ruler::interprete($rule);
        $contextKeys = $ruler->getContextKeys();
        
        //dynamically populate context based on context keys
        $context = getContext (new \Hoa\Ruler\Context(), $contextKeys);
        
        var_dump($ruler->assert($rule, $context));