### PR TITLE
Avoid collisions with user-defined operators…

### DIFF
--- a/Grammar.pp
+++ b/Grammar.pp
@@ -45,16 +45,15 @@
 %skip   space         \s
 
 // Scalars.
-
 %token  true          (?i)true
 %token  false         (?i)false
 %token  null          (?i)null
 
 // Logical operators
-%token  not           (?i)not
-%token  and           (?i)and
-%token  or            (?i)or
-%token  xor           (?i)xor
+%token  not           (?i)not\b
+%token  and           (?i)and\b
+%token  or            (?i)or\b
+%token  xor           (?i)xor\b
 
 // Value
 %token  string        ("|')(.*?)(?<!\\)\1


### PR DESCRIPTION
… by defining a word boundary for logical operators.

For example, if someone is introducing the `not_in` operator, it will create a collision with the `not` token in the lexer (which is logical and not a bug!).
Before the patch:

``` sh
$ echo 'a not_in b' | hoa compiler:pp hoa://Library/Ruler/Grammar.pp 0 -s
 #  namespace     token name            token value                     offset
-------------------------------------------------------------------------------
 0  default       identifier            a                                    0
 1  default       not                   not                                  2
 2  default       identifier            _in                                  5
 3  default       identifier            b                                    9
 4  default       EOF                                                       11
```

(see, `not` and `_in`).
After the patch:

``` sh
$ echo 'a not_in b' | hoa compiler:pp hoa://Library/Ruler/Grammar.pp 0 -s
 #  namespace     token name            token value                     offset
-------------------------------------------------------------------------------
 0  default       identifier            a                                    0
 1  default       identifier            not_in                               2
 2  default       identifier            b                                    9
 3  default       EOF                                                       11
```

Since we accept very dynamic operators, we need to define a “word boundary” for token operators.

Tests are green. Need a review and the test verdict from @stephpy and @shouze :-).
