### PR TITLE
Generating valid PHP code within visit method

### DIFF
--- a/Visitor/Compiler.php
+++ b/Visitor/Compiler.php
@@ -90,6 +90,7 @@ class Compiler implements \Hoa\Visitor\Visit {
             $out  = $_ . '$model->';
             $name = $element->getName();
 
+            $_handle = [];
             if(false === $element->isFunction()) {
 
                 if(true === Core\Consistency::isIdentifier($name))
@@ -99,11 +100,12 @@ class Compiler implements \Hoa\Visitor\Visit {
 
                 $out     .= '(' . "\n";
             }
-            else
-                $out .= 'func(' . "\n" . $_ . '    ' .
-                        '\'' . $name . '\',' . "\n";
+            else {
+                $out .= 'func(' . "\n" . $_ . '    ';
+                $_handle[] = '\'' . $name . '\'';
+            }
 
-            $_handle = [];
+
             ++$this->_indentation;
 
             foreach($element->getArguments() as $argument)


### PR DESCRIPTION
Within the `visit` method, if the `$element` is an **Operator** and `$element->isFunction() === true` and this function is called _without any arguments_ then an invalid PHP code is generated.

e.g.  

```
$model->func('function_name',)
```

When a method has no arguments, the comma that separates the method name from the list of the arguments needs to be removed .
