### PR TITLE
Improve arguments class type

### DIFF
--- a/Visitor/Asserter.php
+++ b/Visitor/Asserter.php
@@ -135,7 +135,7 @@ class Asserter implements Visitor\Visit {
      * @param   mixed                 $eldnah     Handle (not reference).
      * @return  mixed
      */
-    public function visitModel ( Visitor\Element $element, &$handle = null, $eldnah = null ) {
+    public function visitModel ( Ruler\Model $element, &$handle = null, $eldnah = null ) {
 
         return (bool) $element->getExpression()->accept($this, $handle, $eldnah);
     }
@@ -149,7 +149,7 @@ class Asserter implements Visitor\Visit {
      * @param   mixed                 $eldnah     Handle (not reference).
      * @return  mixed
      */
-    protected function visitOperator ( Visitor\Element $element, &$handle = null, $eldnah = null ) {
+    protected function visitOperator ( Ruler\Model\Operator $element, &$handle = null, $eldnah = null ) {
 
         $name      = $element->getName();
         $arguments = [];
@@ -173,7 +173,7 @@ class Asserter implements Visitor\Visit {
      * @param   mixed                 $eldnah     Handle (not reference).
      * @return  mixed
      */
-    protected function visitScalar ( Visitor\Element $element, &$handle = null, $eldnah = null ) {
+    protected function visitScalar ( Ruler\Model\Bag\Scalar $element, &$handle = null, $eldnah = null ) {
 
         return $element->getValue();
     }
@@ -187,7 +187,7 @@ class Asserter implements Visitor\Visit {
      * @param   mixed                 $eldnah     Handle (not reference).
      * @return  array
      */
-    protected function visitArray ( Visitor\Element $element, &$handle = null, $eldnah = null ) {
+    protected function visitArray ( Ruler\Model\Bag\RulerArray $element, &$handle = null, $eldnah = null ) {
 
         $out = [];
 
@@ -206,7 +206,7 @@ class Asserter implements Visitor\Visit {
      * @param   mixed                 $eldnah     Handle (not reference).
      * @return  mixed
      */
-    protected function visitContext ( Visitor\Element $element, &$handle = null, $eldnah = null ) {
+    protected function visitContext ( Ruler\Model\Bag\Context $element, &$handle = null, $eldnah = null ) {
 
         $context = $this->getContext();
 


### PR DESCRIPTION
All arguments in method visitModel visitOperators etc… are class which extends \Hoa\Visitor\Element but there method are protected and used only when we dispatch \Hoa\Visitor\Element and call the method regarding the class. So we can improve arguments class type by specify it.