### PR TITLE
Allow an identifier to start by a digit

### DIFF
--- a/Grammar.pp
+++ b/Grammar.pp
@@ -66,7 +66,7 @@
 %token  comma          ,
 %token  dot           \.
 
-%token  identifier    [^\s\(\)\[\],\.]+
+%token  identifier    (\d+[^\d\s\(\)\[\],\.]+|[^\s\(\)\[\],\.]+)
 
 #expression:
     logical_operation()


### PR DESCRIPTION
Fix https://github.com/hoaproject/Ruler/issues/32.

Guys, the regex is overly complicated. I am still not a big fan of this feature :-(. Do you think it is really needed?