### PR TITLE
Auto-box the expression to its bag representation

### DIFF
--- a/Model/Model.php
+++ b/Model/Model.php
@@ -79,6 +79,12 @@ class Model implements Visitor\Element
             return $this->$name = $value;
         }
 
+        if (is_scalar($value)) {
+            $value = new Bag\Scalar($value);
+        } elseif (is_array($value)) {
+            $value = new Bag\RulerArray($value);
+        }
+
         $this->_root = $value;
 
         return;


### PR DESCRIPTION
Fix #64.

If we have the rule `true`, the interpreter will compute a boolean value `true` for the expression. This is correct. However, it can create an error when we try to assert/evaluate this value because it's not an object, as we might expect. So we auto-box the expression to its bag representation. We decided to do this in the model because it's the most common ancestor between all representations and it holds the real data representation.