### PR TITLE
Add a factory method in Ruler to create a context

### DIFF
--- a/Ruler.php
+++ b/Ruler.php
@@ -210,6 +210,16 @@ class Ruler
 
         return static::$_compiler;
     }
+
+    /**
+     * Create a new context.
+     *
+     * @return \Hoa\Ruler\Context
+     */
+    public function getNewContext()
+    {
+        return new Context();
+    }
 }
 
 /**


### PR DESCRIPTION
As discussed in hoaproject/Contributions-Symfony-RulerBundle#1, `Ruler` should provide a factory method to create a new context.