### PR TITLE
Disassembly: Always add parenthesis around operators

### DIFF
--- a/Test/Unit/Visitor/Disassembly.php
+++ b/Test/Unit/Visitor/Disassembly.php
@@ -80,7 +80,7 @@ class Disassembly extends Test\Unit\Suite
     {
         return $this->_case(
             'true and false',
-            'true and false'
+            '(true and false)'
         );
     }
 
@@ -120,7 +120,7 @@ class Disassembly extends Test\Unit\Suite
     {
         return $this->_case(
             'null and true',
-            'null and true'
+            '(null and true)'
         );
     }
 

--- a/Visitor/Disassembly.php
+++ b/Visitor/Disassembly.php
@@ -77,11 +77,7 @@ class Disassembly implements Visitor\Visit
                 if (!isset($arguments[1])) {
                     $_out = $name . ' ' . $arguments[0];
                 } else {
-                    $_out = $arguments[0] . ' ' . $name . ' ' . $arguments[1];
-                }
-
-                if (false === Ruler\Model\Operator::isToken($name)) {
-                    $_out = '(' . $_out . ')';
+                    $_out = '(' . $arguments[0] . ' ' . $name . ' ' . $arguments[1] . ')';
                 }
 
                 $out .= $_out;


### PR DESCRIPTION
Fix #79.
Fix #80.

Thoughts @stephpy, @Metalaka, @osaris and @shouze.