### PR TITLE
Composer: `hoa/protocol` is explicitly required

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,10 +21,11 @@
         "source": "http://git.hoa-project.net/"
     },
     "require": {
-        "hoa/consistency": "~1.0",
         "hoa/compiler"   : "~3.0",
+        "hoa/consistency": "~1.0",
         "hoa/exception"  : "~1.0",
         "hoa/file"       : "~1.0",
+        "hoa/protocol"   : "~1.0",
         "hoa/visitor"    : "~2.0"
     },
     "require-dev": {


### PR DESCRIPTION
`hoa/protocol` was required by `hoa/compiler`, but it's better to have it as an explicit dependency.