### PR TITLE
Grammar: Chain dimensions on function

### DIFF
--- a/Grammar.pp
+++ b/Grammar.pp
@@ -83,12 +83,15 @@ operand:
 value:
     ::not:: logical_operation() #not
   | <true> | <false> | <null> | <float> | <integer> | <string>
-  | variable()
   | array_declaration()
-  | function_call()
+  | chain()
+
+chain:
+    ( variable() | function_call() )
+    ( ( array_access() | object_access() ) #variable_access )*
 
 variable:
-    <identifier> ( ( array_access() | object_access() ) #variable_access )*
+    <identifier>
 
 #array_access:
     ::bracket_:: value() ::_bracket::

--- a/Model/Operator.php
+++ b/Model/Operator.php
@@ -36,6 +36,7 @@
 
 namespace Hoa\Ruler\Model;
 
+use Hoa\Ruler;
 use Hoa\Visitor;
 
 /**
@@ -46,7 +47,9 @@ use Hoa\Visitor;
  * @copyright  Copyright © 2007-2016 Hoa community
  * @license    New BSD License
  */
-class Operator implements Visitor\Element
+class          Operator
+    extends    Ruler\Model\Bag\Context
+    implements Visitor\Element
 {
     /**
      * Lazy evaluation should break.

--- a/Test/Unit/Model/Operator.php
+++ b/Test/Unit/Model/Operator.php
@@ -61,6 +61,16 @@ class Operator extends Test\Unit\Suite
                     ->isInstanceOf(Visitor\Element::class);
     }
 
+    public function case_is_a_context()
+    {
+        $this
+            ->given($name = 'foo')
+            ->when($result = new SUT($name))
+            ->then
+                ->object($result)
+                    ->isInstanceOf(LUT\Model\Bag\Context::class);
+    }
+
     public function case_constructor()
     {
         $this

--- a/Test/Unit/Visitor/Asserter.php
+++ b/Test/Unit/Visitor/Asserter.php
@@ -1232,6 +1232,6 @@ class C
 
     public function new()
     {
-        return new C();
+        return new self();
     }
 }

--- a/Test/Unit/Visitor/Asserter.php
+++ b/Test/Unit/Visitor/Asserter.php
@@ -546,6 +546,322 @@ class Asserter extends Test\Unit\Suite
                 ->hasMessage('Operator _foo_ does not exist.');
     }
 
+    public function case_visit_operator_array_dimension_1()
+    {
+        $this
+            ->given(
+                $operator = new LUT\Model\Operator('c', [7]),
+                $operator->index('x'),
+                $asserter = new SUT(),
+                $asserter->setOperator(
+                    'c',
+                    function ($x) {
+                        return ['x' => $x * 6];
+                    }
+                )
+            )
+            ->when($result = $this->invoke($asserter)->visitOperator($operator))
+            ->then
+                ->integer($result)
+                    ->isEqualTo(42)
+                ->integer($asserter->visit($operator))
+                    ->isIdenticalTo($result);
+    }
+
+    public function case_visit_operator_array_dimension_2()
+    {
+        $this
+            ->given(
+                $operator = new LUT\Model\Operator('c', [7]),
+                $operator->index('x'),
+                $operator->index('y'),
+                $asserter = new SUT(),
+                $asserter->setOperator(
+                    'c',
+                    function ($x) {
+                        return ['x' => ['y' => $x * 6]];
+                    }
+                )
+            )
+            ->when($result = $this->invoke($asserter)->visitOperator($operator))
+            ->then
+                ->integer($result)
+                    ->isEqualTo(42)
+                ->integer($asserter->visit($operator))
+                    ->isIdenticalTo($result);
+    }
+
+    public function case_visit_operator_array_dimension_1_undefined_index()
+    {
+        $this
+            ->given(
+                $operator = new LUT\Model\Operator('c', [7]),
+                $operator->index('z'),
+                $asserter = new SUT(),
+                $asserter->setOperator(
+                    'c',
+                    function ($x) {
+                        return ['x' => 42];
+                    }
+                )
+            )
+            ->exception(function () use ($asserter, $operator) {
+                $this->invoke($asserter)->visitOperator($operator);
+            })
+                ->isInstanceOf(LUT\Exception\Asserter::class)
+                ->hasMessage('Try to access to an undefined index: z (dimension number 1 of c()).')
+            ->exception(function () use ($asserter, $operator) {
+                $asserter->visit($operator);
+            })
+                ->isInstanceOf(LUT\Exception\Asserter::class)
+                ->hasMessage('Try to access to an undefined index: z (dimension number 1 of c()).');
+    }
+
+    public function case_visit_operator_array_dimension_1_not_an_array()
+    {
+        $this
+            ->given(
+                $operator = new LUT\Model\Operator('c', [7]),
+                $operator->index('y'),
+                $asserter = new SUT(),
+                $asserter->setOperator(
+                    'c',
+                    function ($x) {
+                        return 42;
+                    }
+                )
+            )
+            ->exception(function () use ($asserter, $operator) {
+                $this->invoke($asserter)->visitOperator($operator);
+            })
+                ->isInstanceOf(LUT\Exception\Asserter::class)
+                ->hasMessage('Try to access to an undefined index: y (dimension number 1 of c()), because it is not an array.')
+            ->exception(function () use ($asserter, $operator) {
+                $asserter->visit($operator);
+            })
+                ->isInstanceOf(LUT\Exception\Asserter::class)
+                ->hasMessage('Try to access to an undefined index: y (dimension number 1 of c()), because it is not an array.');
+    }
+
+    public function case_visit_operator_attribute_dimension_1()
+    {
+        $this
+            ->given(
+                $operator = new LUT\Model\Operator('c', [7]),
+                $operator->attribute('x'),
+                $asserter = new SUT(),
+                $asserter->setOperator(
+                    'c',
+                    function ($x) {
+                        return (object) ['x' => $x * 6];
+                    }
+                )
+            )
+            ->when($result = $this->invoke($asserter)->visitOperator($operator))
+            ->then
+                ->integer($result)
+                    ->isEqualTo(42)
+                ->integer($asserter->visit($operator))
+                    ->isIdenticalTo($result);
+    }
+
+    public function case_visit_operator_attribute_dimension_2()
+    {
+        $this
+            ->given(
+                $operator = new LUT\Model\Operator('c', [7]),
+                $operator->attribute('x'),
+                $operator->attribute('y'),
+                $asserter = new SUT(),
+                $asserter->setOperator(
+                    'c',
+                    function ($x) {
+                        return (object) ['x' => (object) ['y' => $x * 6]];
+                    }
+                )
+            )
+            ->when($result = $this->invoke($asserter)->visitOperator($operator))
+            ->then
+                ->integer($result)
+                    ->isEqualTo(42)
+                ->integer($asserter->visit($operator))
+                    ->isIdenticalTo($result);
+    }
+
+    public function case_visit_operator_attribute_dimension_1_undefined_name()
+    {
+        $this
+            ->given(
+                $operator = new LUT\Model\Operator('c', [7]),
+                $operator->attribute('y'),
+                $asserter = new SUT(),
+                $asserter->setOperator(
+                    'c',
+                    function ($x) {
+                        return (object) ['x' => $x * 6];
+                    }
+                )
+            )
+            ->exception(function () use ($asserter, $operator) {
+                $this->invoke($asserter)->visitOperator($operator);
+            })
+                ->isInstanceOf(LUT\Exception\Asserter::class)
+                ->hasMessage('Try to read an undefined attribute: y (dimension number 1 of c()).')
+            ->exception(function () use ($asserter, $operator) {
+                $asserter->visit($operator);
+            })
+                ->isInstanceOf(LUT\Exception\Asserter::class)
+                ->hasMessage('Try to read an undefined attribute: y (dimension number 1 of c()).');
+    }
+
+    public function case_visit_operator_attribute_dimension_1_not_an_object()
+    {
+        $this
+            ->given(
+                $operator = new LUT\Model\Operator('c', [7]),
+                $operator->attribute('x'),
+                $asserter = new SUT(),
+                $asserter->setOperator(
+                    'c',
+                    function ($x) {
+                        return $x * 6;
+                    }
+                )
+            )
+            ->exception(function () use ($asserter, $operator) {
+                $this->invoke($asserter)->visitOperator($operator);
+            })
+                ->isInstanceOf(LUT\Exception\Asserter::class)
+                ->hasMessage('Try to read an undefined attribute: x (dimension number 1 of c()), because it is not an object.')
+            ->exception(function () use ($asserter, $operator) {
+                $asserter->visit($operator);
+            })
+                ->isInstanceOf(LUT\Exception\Asserter::class)
+                ->hasMessage('Try to read an undefined attribute: x (dimension number 1 of c()), because it is not an object.');
+    }
+
+    public function case_visit_operator_method_dimension_1()
+    {
+        $this
+            ->given(
+                $operator = new LUT\Model\Operator('c'),
+                $operator->call(new LUT\Model\Operator('f', [7, 35])),
+                $context  = new LUT\Context(['x' => new C()]),
+                $asserter = new SUT($context),
+                $asserter->setOperator(
+                    'c',
+                    function () {
+                        return new C();
+                    }
+                )
+            )
+            ->when($result = $this->invoke($asserter)->visitOperator($operator))
+            ->then
+                ->integer($result)
+                    ->isEqualTo(42)
+                ->integer($asserter->visit($operator))
+                    ->isIdenticalTo($result);
+    }
+
+    public function case_visit_operator_method_dimension_2()
+    {
+        $this
+            ->given(
+                $operator = new LUT\Model\Operator('c'),
+                $operator->call(new LUT\Model\Operator('new')),
+                $operator->call(new LUT\Model\Operator('f', [7, 35])),
+                $asserter = new SUT(),
+                $asserter->setOperator(
+                    'c',
+                    function () {
+                        return new C();
+                    }
+                )
+            )
+            ->when($result = $this->invoke($asserter)->visitOperator($operator))
+            ->then
+                ->integer($result)
+                    ->isEqualTo(42)
+                ->integer($asserter->visit($operator))
+                    ->isIdenticalTo($result);
+    }
+
+    public function case_visit_operator_method_dimension_1_undefined_method()
+    {
+        $this
+            ->given(
+                $operator = new LUT\Model\Operator('c'),
+                $operator->call(new LUT\Model\Operator('h')),
+                $asserter = new SUT(),
+                $asserter->setOperator(
+                    'c',
+                    function () {
+                        return new C();
+                    }
+                )
+            )
+            ->exception(function () use ($asserter, $operator) {
+                $this->invoke($asserter)->visitOperator($operator);
+            })
+                ->isInstanceOf(LUT\Exception\Asserter::class)
+                ->hasMessage('Try to call an undefined method: h (dimension number 1 of c()).')
+            ->exception(function () use ($asserter, $operator) {
+                $asserter->visit($operator);
+            })
+                ->isInstanceOf(LUT\Exception\Asserter::class)
+                ->hasMessage('Try to call an undefined method: h (dimension number 1 of c()).');
+    }
+
+    public function case_visit_operator_method_dimension_1_not_an_object()
+    {
+        $this
+            ->given(
+                $operator = new LUT\Model\Operator('c'),
+                $operator->call(new LUT\Model\Operator('f', [7, 35])),
+                $asserter = new SUT(),
+                $asserter->setOperator(
+                    'c',
+                    function () {
+                        return 42;
+                    }
+                )
+            )
+            ->exception(function () use ($asserter, $operator) {
+                $this->invoke($asserter)->visitOperator($operator);
+            })
+                ->isInstanceOf(LUT\Exception\Asserter::class)
+                ->hasMessage('Try to call an undefined method: f (dimension number 1 of c()), because it is not an object.')
+            ->exception(function () use ($asserter, $operator) {
+                $asserter->visit($operator);
+            })
+                ->isInstanceOf(LUT\Exception\Asserter::class)
+                ->hasMessage('Try to call an undefined method: f (dimension number 1 of c()), because it is not an object.');
+    }
+
+    public function case_visit_operator_mixed_dimensions()
+    {
+        $this
+            ->given(
+                $operator = new LUT\Model\Operator('c'),
+                $operator->index('x'),
+                $operator->attribute('y'),
+                $operator->call(new LUT\Model\Operator('f', [7, 35])),
+                $asserter = new SUT(),
+                $asserter->setOperator(
+                    'c',
+                    function () {
+                        return ['x' => (object) ['y' => new C()]];
+                    }
+                )
+            )
+            ->when($result = $this->invoke($asserter)->visitOperator($operator))
+            ->then
+                ->integer($result)
+                    ->isEqualTo(42)
+                ->integer($asserter->visit($operator))
+                    ->isIdenticalTo($result);
+    }
+
     public function case_visit_scalar_null()
     {
         return $this->_case_visit_scalar(null);
@@ -640,7 +956,7 @@ class Asserter extends Test\Unit\Suite
                 ->hasMessage('Context reference x does not exist.');
     }
 
-    public function case_visit_context_dimension_0()
+    public function case_visit_context()
     {
         $this
             ->given(

--- a/Test/Unit/Visitor/Compiler.php
+++ b/Test/Unit/Visitor/Compiler.php
@@ -123,6 +123,78 @@ class Compiler extends Test\Unit\Suite
         );
     }
 
+    public function case_function_with_array_dimension()
+    {
+        return $this->_case(
+            'x(7)[42]',
+            '$model = new \Hoa\Ruler\Model();' . "\n" .
+            '$model->expression =' . "\n" .
+            '    $model->func(' . "\n" .
+            '        \'x\',' . "\n" .
+            '        7' . "\n" .
+            '    )' . "\n" .
+            '        ->index(' . "\n" .
+            '            42' . "\n" .
+            '        );'
+        );
+    }
+
+    public function case_function_with_attribute_dimension()
+    {
+        return $this->_case(
+            'x(7).y',
+            '$model = new \Hoa\Ruler\Model();' . "\n" .
+            '$model->expression =' . "\n" .
+            '    $model->func(' . "\n" .
+            '        \'x\',' . "\n" .
+            '        7' . "\n" .
+            '    )' . "\n" .
+            '        ->attribute(\'y\');'
+        );
+    }
+
+    public function case_function_with_call_dimension()
+    {
+        return $this->_case(
+            'x(7).y(42)',
+            '$model = new \Hoa\Ruler\Model();' . "\n" .
+            '$model->expression =' . "\n" .
+            '    $model->func(' . "\n" .
+            '        \'x\',' . "\n" .
+            '        7' . "\n" .
+            '    )' . "\n" .
+            '        ->call(' . "\n" .
+            '            $model->func(' . "\n" .
+            '                \'y\',' . "\n" .
+            '                42' . "\n" .
+            '            )' . "\n" .
+            '        );'
+        );
+    }
+
+    public function case_function_with_many_dimensions()
+    {
+        return $this->_case(
+            'x(7).y(42).z[153]',
+            '$model = new \Hoa\Ruler\Model();' . "\n" .
+            '$model->expression =' . "\n" .
+            '    $model->func(' . "\n" .
+            '        \'x\',' . "\n" .
+            '        7' . "\n" .
+            '    )' . "\n" .
+            '        ->call(' . "\n" .
+            '            $model->func(' . "\n" .
+            '                \'y\',' . "\n" .
+            '                42' . "\n" .
+            '            )' . "\n" .
+            '        )' . "\n" .
+            '        ->attribute(\'z\')' . "\n" .
+            '        ->index(' . "\n" .
+            '            153' . "\n" .
+            '        );'
+        );
+    }
+
     public function case_scalar_true()
     {
         return $this->_case(
@@ -223,6 +295,22 @@ class Compiler extends Test\Unit\Suite
         );
     }
 
+    public function case_context_with_array_dimensions()
+    {
+        return $this->_case(
+            'x[7][42]',
+            '$model = new \Hoa\Ruler\Model();' . "\n" .
+            '$model->expression =' . "\n" .
+            '    $model->variable(\'x\')' . "\n" .
+            '        ->index(' . "\n" .
+            '            7' . "\n" .
+            '        )' . "\n" .
+            '        ->index(' . "\n" .
+            '            42' . "\n" .
+            '        );'
+        );
+    }
+
     public function case_context_with_attribute_dimension()
     {
         return $this->_case(
@@ -231,6 +319,18 @@ class Compiler extends Test\Unit\Suite
             '$model->expression =' . "\n" .
             '    $model->variable(\'x\')' . "\n" .
             '        ->attribute(\'y\');'
+        );
+    }
+
+    public function case_context_with_attribute_dimensions()
+    {
+        return $this->_case(
+            'x.y.z',
+            '$model = new \Hoa\Ruler\Model();' . "\n" .
+            '$model->expression =' . "\n" .
+            '    $model->variable(\'x\')' . "\n" .
+            '        ->attribute(\'y\')' . "\n" .
+            '        ->attribute(\'z\');'
         );
     }
 
@@ -250,10 +350,10 @@ class Compiler extends Test\Unit\Suite
         );
     }
 
-    public function case_context_with_many_dimensions()
+    public function case_context_with_call_dimensions()
     {
         return $this->_case(
-            'x.y(7).z[42]',
+            'x.y(7).z(42)',
             '$model = new \Hoa\Ruler\Model();' . "\n" .
             '$model->expression =' . "\n" .
             '    $model->variable(\'x\')' . "\n" .
@@ -263,10 +363,40 @@ class Compiler extends Test\Unit\Suite
             '                7' . "\n" .
             '            )' . "\n" .
             '        )' . "\n" .
-            '        ->attribute(\'z\')' . "\n" .
+            '        ->call(' . "\n" .
+            '            $model->func(' . "\n" .
+            '                \'z\',' . "\n" .
+            '                42' . "\n" .
+            '            )' . "\n" .
+            '        );'
+        );
+    }
+
+    public function case_context_with_many_dimensions()
+    {
+        return $this->_case(
+            'a.b(7).c[42].d.e(153).f',
+            '$model = new \Hoa\Ruler\Model();' . "\n" .
+            '$model->expression =' . "\n" .
+            '    $model->variable(\'a\')' . "\n" .
+            '        ->call(' . "\n" .
+            '            $model->func(' . "\n" .
+            '                \'b\',' . "\n" .
+            '                7' . "\n" .
+            '            )' . "\n" .
+            '        )' . "\n" .
+            '        ->attribute(\'c\')' . "\n" .
             '        ->index(' . "\n" .
             '            42' . "\n" .
-            '        );'
+            '        )' . "\n" .
+            '        ->attribute(\'d\')' . "\n" .
+            '        ->call(' . "\n" .
+            '            $model->func(' . "\n" .
+            '                \'e\',' . "\n" .
+            '                153' . "\n" .
+            '            )' . "\n" .
+            '        )' . "\n" .
+            '        ->attribute(\'f\');'
         );
     }
 

--- a/Test/Unit/Visitor/Disassembly.php
+++ b/Test/Unit/Visitor/Disassembly.php
@@ -100,6 +100,38 @@ class Disassembly extends Test\Unit\Suite
         );
     }
 
+    public function case_function_with_array_dimensions()
+    {
+        return $this->_case(
+            'x(7)[42]',
+            'x(7)[42]'
+        );
+    }
+
+    public function case_function_with_attribute_dimensions()
+    {
+        return $this->_case(
+            'x(7).y',
+            'x(7).y'
+        );
+    }
+
+    public function case_function_with_call_dimensions()
+    {
+        return $this->_case(
+            'x(7).y(42)',
+            'x(7).y(42)'
+        );
+    }
+
+    public function case_function_with_many_dimensions()
+    {
+        return $this->_case(
+            'x(7).y(42).z[153]',
+            'x(7).y(42).z[153]'
+        );
+    }
+
     public function case_scalar_true()
     {
         return $this->_case(

--- a/Test/Unit/Visitor/Interpreter.php
+++ b/Test/Unit/Visitor/Interpreter.php
@@ -359,6 +359,26 @@ class Interpreter extends Test\Unit\Suite
         );
     }
 
+    public function case_context_with_array_dimensions()
+    {
+        return $this->_case(
+            'x[7][42]',
+            function () {
+                $model = new LUT\Model();
+                $model->expression =
+                    $model->variable('x')
+                        ->index(
+                            7
+                        )
+                        ->index(
+                            42
+                        );
+
+                return $model;
+            }
+        );
+    }
+
     public function case_context_with_attribute_dimension()
     {
         return $this->_case(
@@ -368,6 +388,22 @@ class Interpreter extends Test\Unit\Suite
                 $model->expression =
                     $model->variable('x')
                         ->attribute('y');
+
+                return $model;
+            }
+        );
+    }
+
+    public function case_context_with_attribute_dimensions()
+    {
+        return $this->_case(
+            'x.y.z',
+            function () {
+                $model = new LUT\Model();
+                $model->expression =
+                    $model->variable('x')
+                        ->attribute('y')
+                        ->attribute('z');
 
                 return $model;
             }
@@ -386,6 +422,32 @@ class Interpreter extends Test\Unit\Suite
                             $model->func(
                                 'y',
                                 7
+                            )
+                        );
+
+                return $model;
+            }
+        );
+    }
+
+    public function case_context_with_call_dimensions()
+    {
+        return $this->_case(
+            'x.y(7).z(42)',
+            function () {
+                $model = new LUT\Model();
+                $model->expression =
+                    $model->variable('x')
+                        ->call(
+                            $model->func(
+                                'y',
+                                7
+                            )
+                        )
+                        ->call(
+                            $model->func(
+                                'z',
+                                42
                             )
                         );
 

--- a/Test/Unit/Visitor/Interpreter.php
+++ b/Test/Unit/Visitor/Interpreter.php
@@ -459,21 +459,29 @@ class Interpreter extends Test\Unit\Suite
     public function case_context_with_many_dimensions()
     {
         return $this->_case(
-            'x.y(7).z[42]',
+            'a.b(7).c[42].d.e(153).f',
             function () {
                 $model = new LUT\Model();
                 $model->expression =
-                    $model->variable('x')
+                    $model->variable('a')
                         ->call(
                             $model->func(
-                                'y',
+                                'b',
                                 7
                             )
                         )
-                        ->attribute('z')
+                        ->attribute('c')
                         ->index(
                             42
-                        );
+                        )
+                        ->attribute('d')
+                        ->call(
+                            $model->func(
+                                'e',
+                                153
+                            )
+                        )
+                        ->attribute('f');
 
                 return $model;
             }

--- a/Test/Unit/Visitor/Interpreter.php
+++ b/Test/Unit/Visitor/Interpreter.php
@@ -209,6 +209,94 @@ class Interpreter extends Test\Unit\Suite
         );
     }
 
+    public function case_function_with_array_dimension()
+    {
+        return $this->_case(
+            'x(7)[42]',
+            function () {
+                $model = new LUT\Model();
+                $model->expression =
+                    $model->func(
+                        'x',
+                        7
+                    )
+                        ->index(
+                            42
+                        );
+
+                return $model;
+            }
+        );
+    }
+
+    public function case_function_with_attribute_dimension()
+    {
+        return $this->_case(
+            'x(7).y',
+            function () {
+                $model = new LUT\Model();
+                $model->expression =
+                    $model->func(
+                        'x',
+                        7
+                    )
+                        ->attribute('y');
+
+                return $model;
+            }
+        );
+    }
+
+    public function case_function_with_call_dimension()
+    {
+        return $this->_case(
+            'x(7).y(42)',
+            function () {
+                $model = new LUT\Model();
+                $model->expression =
+                    $model->func(
+                        'x',
+                        7
+                    )
+                        ->call(
+                            $model->func(
+                                'y',
+                                42
+                            )
+                        );
+
+                return $model;
+            }
+        );
+    }
+
+    public function case_function_with_many_dimensions()
+    {
+        return $this->_case(
+            'x(7).y(42).z[153]',
+            function () {
+                $model = new LUT\Model();
+                $model->expression =
+                    $model->func(
+                        'x',
+                        7
+                    )
+                        ->call(
+                            $model->func(
+                                'y',
+                                42
+                            )
+                        )
+                        ->attribute('z')
+                        ->index(
+                            153
+                        );
+
+                return $model;
+            }
+        );
+    }
+
     public function case_scalar_true()
     {
         return $this->_case(
@@ -404,52 +492,6 @@ class Interpreter extends Test\Unit\Suite
                     $model->variable('x')
                         ->attribute('y')
                         ->attribute('z');
-
-                return $model;
-            }
-        );
-    }
-
-    public function case_context_with_call_dimension()
-    {
-        return $this->_case(
-            'x.y(7)',
-            function () {
-                $model = new LUT\Model();
-                $model->expression =
-                    $model->variable('x')
-                        ->call(
-                            $model->func(
-                                'y',
-                                7
-                            )
-                        );
-
-                return $model;
-            }
-        );
-    }
-
-    public function case_context_with_call_dimensions()
-    {
-        return $this->_case(
-            'x.y(7).z(42)',
-            function () {
-                $model = new LUT\Model();
-                $model->expression =
-                    $model->variable('x')
-                        ->call(
-                            $model->func(
-                                'y',
-                                7
-                            )
-                        )
-                        ->call(
-                            $model->func(
-                                'z',
-                                42
-                            )
-                        );
 
                 return $model;
             }

--- a/Visitor/Asserter.php
+++ b/Visitor/Asserter.php
@@ -174,7 +174,15 @@ class Asserter implements Visitor\Visit
             );
         }
 
-        return $this->getOperator($name)->distributeArguments($arguments);
+        $value = $this->getOperator($name)->distributeArguments($arguments);
+
+        return $this->visitDimensions(
+            $element,
+            $name . '()',
+            $value,
+            $handle,
+            $eldnah
+        );
     }
 
     /**
@@ -238,18 +246,44 @@ class Asserter implements Visitor\Visit
             );
         }
 
-        $contextPointer = $context[$id];
+        return $this->visitDimensions(
+            $element,
+            $id,
+            $context[$id],
+            $handle,
+            $eldnah
+        );
+    }
+
+    /**
+     * Visit dimensions of a context.
+     *
+     * @param   \Hoa\Visitor\Element  $element      Element to visit.
+     * @param   string                $elementId    Element name.
+     * @param   mixed                 $subject      Current root to apply the dimensions.
+     * @param   mixed                 &$handle      Handle (reference).
+     * @param   mixed                 $eldnah       Handle (not reference).
+     * @return  mixed
+     */
+    protected function visitDimensions(
+        Ruler\Model\Bag\Context $element,
+        $elementId,
+        $subject,
+        &$handle = null,
+        $eldnah  = null
+    ) {
+        $pointer = $subject;
 
         foreach ($element->getDimensions() as $dimensionNumber => $dimension) {
             ++$dimensionNumber;
 
             switch ($dimension[Ruler\Model\Bag\Context::ACCESS_TYPE]) {
                 case Ruler\Model\Bag\Context::ARRAY_ACCESS:
-                    $this->visitContextArray(
-                        $contextPointer,
+                    $this->visitArrayDimension(
+                        $pointer,
                         $dimension,
                         $dimensionNumber,
-                        $id,
+                        $elementId,
                         $handle,
                         $eldnah
                     );
@@ -257,11 +291,11 @@ class Asserter implements Visitor\Visit
                     break;
 
                 case Ruler\Model\Bag\Context::ATTRIBUTE_ACCESS:
-                    $this->visitContextAttribute(
-                        $contextPointer,
+                    $this->visitAttributeDimension(
+                        $pointer,
                         $dimension,
                         $dimensionNumber,
-                        $id,
+                        $elementId,
                         $handle,
                         $eldnah
                     );
@@ -269,11 +303,11 @@ class Asserter implements Visitor\Visit
                     break;
 
                 case Ruler\Model\Bag\Context::METHOD_ACCESS:
-                    $this->visitContextMethod(
-                        $contextPointer,
+                    $this->visitMethodDimension(
+                        $pointer,
                         $dimension,
                         $dimensionNumber,
-                        $id,
+                        $elementId,
                         $handle,
                         $eldnah
                     );
@@ -282,11 +316,11 @@ class Asserter implements Visitor\Visit
             }
         }
 
-        return $contextPointer;
+        return $pointer;
     }
 
     /**
-     * Visit a context array
+     * Visit an array dimension.
      *
      * @param   mixed   &$contextPointer    Pointer to the current context.
      * @param   array   $dimension          Dimension bucket.
@@ -296,7 +330,7 @@ class Asserter implements Visitor\Visit
      * @param   mixed   $eldnah             Handle (not reference).
      * @return  void
      */
-    protected function visitContextArray(
+    protected function visitArrayDimension(
         &$contextPointer,
         array $dimension,
         $dimensionNumber,
@@ -333,7 +367,7 @@ class Asserter implements Visitor\Visit
 
 
     /**
-     * Visit a context attribute
+     * Visit an attribute dimension.
      *
      * @param   mixed   &$contextPointer    Pointer to the current context.
      * @param   array   $dimension          Dimension bucket.
@@ -343,7 +377,7 @@ class Asserter implements Visitor\Visit
      * @param   mixed   $eldnah             Handle (not reference).
      * @return  void
      */
-    protected function visitContextAttribute(
+    protected function visitAttributeDimension(
         &$contextPointer,
         array $dimension,
         $dimensionNumber,
@@ -378,7 +412,7 @@ class Asserter implements Visitor\Visit
     }
 
     /**
-     * Visit a context method
+     * Visit a method dimension.
      *
      * @param   mixed   &$contextPointer    Pointer to the current context.
      * @param   array   $dimension          Dimension bucket.
@@ -388,7 +422,7 @@ class Asserter implements Visitor\Visit
      * @param   mixed   $eldnah             Handle (not reference).
      * @return  void
      */
-    protected function visitContextMethod(
+    protected function visitMethodDimension(
         &$contextPointer,
         array $dimension,
         $dimensionNumber,

--- a/Visitor/Compiler.php
+++ b/Visitor/Compiler.php
@@ -128,7 +128,7 @@ class Compiler implements Visitor\Visit
             } elseif (is_numeric($value)) {
                 $out .= (string) $value;
             } else {
-                $out .= '\'' . str_replace(['\'', '\\\\',], ['\\\'', '\\'], $value) . '\'';
+                $out .= '\'' . str_replace(['\'', '\\\\'], ['\\\'', '\\'], $value) . '\'';
             }
         } elseif ($element instanceof Ruler\Model\Bag\RulerArray) {
             $values = [];

--- a/Visitor/Disassembly.php
+++ b/Visitor/Disassembly.php
@@ -82,6 +82,8 @@ class Disassembly implements Visitor\Visit
 
                 $out .= $_out;
             }
+
+            $out .= $this->visitContext($element, $handle, $eldnah);
         } elseif ($element instanceof Ruler\Model\Bag\Scalar) {
             $value = $element->getValue();
 
@@ -105,30 +107,45 @@ class Disassembly implements Visitor\Visit
 
             $out .= '[' . implode(', ', $values) . ']';
         } elseif ($element instanceof Ruler\Model\Bag\Context) {
-            $out .= $element->getId();
+            $out .= $element->getId() . $this->visitContext($element, $handle, $eldnah);
+        }
 
-            foreach ($element->getDimensions() as $dimension) {
-                $value = $dimension[Ruler\Model\Bag\Context::ACCESS_VALUE];
+        return $out;
+    }
 
-                switch ($dimension[Ruler\Model\Bag\Context::ACCESS_TYPE]) {
-                    case Ruler\Model\Bag\Context::ARRAY_ACCESS:
-                        $out .=
-                            '[' .
-                            $value->accept($this, $handle, $eldnah) .
-                            ']';
+    /**
+     * Visit a context.
+     *
+     * @param   \Hoa\Ruler\Model\Bag\Context  $context    Context.
+     * @param   mixed                         &$handle    Handle (reference).
+     * @param   mixed                         $eldnah     Handle (not reference).
+     * @return  mixed
+     */
+    protected function visitContext(Ruler\Model\Bag\Context $context, &$handle, $eldnah)
+    {
+        $out = null;
 
-                        break;
+        foreach ($context->getDimensions() as $dimension) {
+            $value = $dimension[Ruler\Model\Bag\Context::ACCESS_VALUE];
 
-                    case Ruler\Model\Bag\Context::ATTRIBUTE_ACCESS:
-                        $out .= '.' . $value;
+            switch ($dimension[Ruler\Model\Bag\Context::ACCESS_TYPE]) {
+                case Ruler\Model\Bag\Context::ARRAY_ACCESS:
+                    $out .=
+                        '[' .
+                        $value->accept($this, $handle, $eldnah) .
+                        ']';
 
-                        break;
+                    break;
 
-                    case Ruler\Model\Bag\Context::METHOD_ACCESS:
-                        $out .= '.' . $value->accept($this, $handle, $eldnah);
+                case Ruler\Model\Bag\Context::ATTRIBUTE_ACCESS:
+                    $out .= '.' . $value;
 
-                        break;
-                }
+                    break;
+
+                case Ruler\Model\Bag\Context::METHOD_ACCESS:
+                    $out .= '.' . $value->accept($this, $handle, $eldnah);
+
+                    break;
             }
         }
 


### PR DESCRIPTION
Fix #45.

It was only possible to call dimensions on a variable, so:

    x.y[7].z(42)

but it was not possible to start from a function call instead of a variable. This PR fixes this by introducing the `chain` rule that aggregates the “call dimensions” for variable and function call.

The AST is the same but the model needs to be updated. Backward compatibility is kept. The `Model\Operator` class extends the `Model\Bag\Context` to be able to call attributes, indexes and calls. A context is a variable, this is a different naming.