### PR TITLE
Grammar: Logical operators are left-associative

### DIFF
--- a/Grammar.pp
+++ b/Grammar.pp
@@ -67,21 +67,25 @@
 %token  identifier    [^\s\(\)\[\],\.]+
 
 #expression:
-    logical_operation()
+    logical_operation_primary()
 
-logical_operation:
+logical_operation_primary:
+    logical_operation_secondary()
+    ( ( ::or:: #or | ::xor:: #xor ) logical_operation_primary() )?
+
+logical_operation_secondary:
     operation()
-    ( ( ::and:: #and | ::or:: #or | ::xor:: #xor ) logical_operation() )?
+    ( ::and:: #and logical_operation_secondary() )?
 
 operation:
-    operand() ( <identifier> logical_operation() #operation )?
+    operand() ( <identifier> logical_operation_primary() #operation )?
 
 operand:
-    ::parenthesis_:: logical_operation() ::_parenthesis::
+    ::parenthesis_:: logical_operation_primary() ::_parenthesis::
   | value()
 
 value:
-    ::not:: logical_operation() #not
+    ::not:: logical_operation_primary() #not
   | <true> | <false> | <null> | <float> | <integer> | <string>
   | array_declaration()
   | chain()
@@ -104,5 +108,5 @@ object_access:
 
 #function_call:
     <identifier> ::parenthesis_::
-    ( logical_operation() ( ::comma:: logical_operation() )* )?
+    ( logical_operation_primary() ( ::comma:: logical_operation_primary() )* )?
     ::_parenthesis::

--- a/Test/Unit/Issue.php
+++ b/Test/Unit/Issue.php
@@ -79,4 +79,43 @@ class Issue extends Test\Unit\Suite implements Test\Decorrelated
                 ->boolean($result)
                     ->isTrue();
     }
+
+    public function case_github_100_1()
+    {
+        $this
+            ->given(
+                $ruler = new LUT(),
+                $rule  = '(false and true) or true'
+            )
+            ->when($result = $ruler->assert($rule))
+            ->then
+                ->boolean($result)
+                    ->isTrue();
+    }
+
+    public function case_github_100_2()
+    {
+        $this
+            ->given(
+                $ruler = new LUT(),
+                $rule  = 'false and true or true'
+            )
+            ->when($result = $ruler->assert($rule))
+            ->then
+                ->boolean($result)
+                    ->isTrue();
+    }
+
+    public function case_github_100_3()
+    {
+        $this
+            ->given(
+                $ruler = new LUT(),
+                $rule  = 'true or true and false'
+            )
+            ->when($result = $ruler->assert($rule))
+            ->then
+                ->boolean($result)
+                    ->isTrue();
+    }
 }


### PR DESCRIPTION
Fix #100.

Logical operators are commonly left-associative, and so it is in PHP. This patch change the associativity from right- to left-.

This patch is easy. We should have consider having logical operator left-to-right associative from day 1. Now, I am afraid it would introduce regressions. *But*, this is a bug. No one expects logical operators to be right-to-left associative. So I suggest to fix the bug, and to not consider this as a BC break.

Thoughts @hoaproject/hoackers?