### PR TITLE
Enhanced Context to access offsets as object properties.

### DIFF
--- a/Context.php
+++ b/Context.php
@@ -145,4 +145,28 @@ class Context implements \ArrayAccess
 
         return;
     }
+
+    /**
+     * Get a data as context property
+     *
+     * @param   string $name
+     * @return  mixed
+     * @throws  \Hoa\Ruler\Exception
+     */
+    public function __get($name)
+    {
+        return $this->offsetGet($name);
+    }
+
+    /**
+     * Set a data as context property
+     *
+     * @param   string  $id       ID.
+     * @param   mixed   $value    Value.
+     * @return  void
+     */
+    public function __set($id, $value)
+    {
+        $this->offsetSet($id, $value);
+    }
 }

--- a/Test/Unit/Context.php
+++ b/Test/Unit/Context.php
@@ -244,6 +244,24 @@ class Context extends Test\Unit\Suite
             ->when($result = $context['foo']);
     }
 
+    public function case_access_as_properties()
+    {
+        $this
+            ->given(
+                $self = $this,
+                $context = new CUT(),
+                $context['foo'] = 42
+            )
+            ->when($result = $context->foo)
+            ->then
+                ->integer($result)
+                    ->isEqualTo(42)
+            ->when($context->bar = 24)
+            ->then
+                ->integer($context['bar'])
+                    ->isEqualTo(24);
+    }
+
     public function fakeCallable()
     {
         return fakeCallable();


### PR DESCRIPTION
This commit enhances Context behavior so the following context

```php
$context = new Context();
$context['user'] = new Context([
   'activityIndex' => function () use ($activityCalculator) {
       // Takes a lot of time to calculate
       return $activityCalculator($user);
   }
]);
```

Can be accessed with either an array

```php
user['activityIndex'] > 20
```

or an object syntax

```php
user.activityIndex > 20
```